### PR TITLE
📃 Reciept download feature

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -17,18 +17,13 @@ export async function apiService<T>(
 ): Promise<ApiResponse<T>> {
     const url = `${API_PROXY_PREFIX}${endpoint}`;
 
-    // Determina si el cuerpo es FormData
     const isFormData = options.body instanceof FormData;
 
-    // Clona los headers para poder modificarlos de forma segura
     const headers = new Headers(options.headers);
 
     if (isFormData) {
-        // Si es FormData, BORRAMOS el Content-Type.
-        // El navegador lo establecerá automáticamente con el 'boundary' correcto.
         headers.delete("Content-Type");
     } else if (!headers.has("Content-Type")) {
-        // Si no es FormData y no se ha especificado un Content-Type, asumimos JSON.
         headers.set("Content-Type", "application/json");
     }
 
@@ -55,7 +50,6 @@ export async function apiService<T>(
             return new Promise(() => {});
         }
 
-        // Si la respuesta no tiene contenido (ej. DELETE exitoso), retornamos éxito
         if (response.status === 204) {
             return {
                 success: true,

--- a/src/api/customerApi.ts
+++ b/src/api/customerApi.ts
@@ -83,7 +83,7 @@ export async function downloadReceiptApi(
     month: number
 ): Promise<ApiResponse<Response>> {
     const response = await downloadApiService(
-        `/api/factura/generar?clienteNit=${nit}&anio=${anio}&mes=${month}`,
+        `/api/factura/generar-pdf?clienteNit=${nit}&anio=${anio}&mes=${month}`,
         {
             method: "GET",
         }

--- a/src/app/(main)/customers/page.tsx
+++ b/src/app/(main)/customers/page.tsx
@@ -46,18 +46,13 @@ const ClientManagementPage = () => {
     const [isModalDownloadReceiptOpen, setIsModalDownloadReceiptOpen] =
         useState(false);
 
-    // State para el NIT del menú abierto
     const [openMenuNit, setOpenMenuNit] = useState<number | null>(null);
     const [counterUser, setCounterUser] = useState<string>("");
 
-    // NUEVO: State para guardar el estilo de posición del menú (top, left)
     const [menuStyle, setMenuStyle] = useState({});
 
     const menuRef = useRef<HTMLDivElement | null>(null);
     const menuButtonRefs = useRef<(HTMLButtonElement | null)[]>([]);
-    // Ya no necesitamos la ref del contenedor de la tabla para el overflow
-    // const tableContainerRef = useRef<HTMLDivElement | null>(null);
-
     const [loading, setLoading] = useState<boolean>(true);
     const [isModalPrintersFile, setIsModalPrintersFile] = useState(false);
     const [loadingClients, setLoadingClients] = React.useState<boolean>(false);

--- a/src/app/api/[...path]/route.ts
+++ b/src/app/api/[...path]/route.ts
@@ -2,6 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 
+type RequestInitWithDuplex = RequestInit & {
+    duplex?: "half" | "full" | "auto";
+};
+
 async function handler(request: NextRequest) {
     const token = request.cookies.get("auth-token")?.value;
 
@@ -16,10 +20,6 @@ async function handler(request: NextRequest) {
     requestHeaders.set("Authorization", `Bearer ${token}`);
     requestHeaders.delete("host");
 
-    type RequestInitWithDuplex = RequestInit & {
-        duplex?: "half" | "full" | "auto";
-    };
-
     const fetchOptions: RequestInitWithDuplex = {
         method: request.method,
         headers: requestHeaders,
@@ -28,7 +28,7 @@ async function handler(request: NextRequest) {
     // Only set the body for methods that typically have one
     if (request.method !== "GET" && request.method !== "HEAD") {
         fetchOptions.body = request.body;
-        fetchOptions.duplex = "half" as "half";
+        fetchOptions.duplex = "half" as const;
     }
 
     try {

--- a/src/components/ui/Checkout/SliderCheckout.tsx
+++ b/src/components/ui/Checkout/SliderCheckout.tsx
@@ -52,24 +52,19 @@ export const SliderCheckout = ({
             if (response.status && response.data) {
                 const { blob, estadoFactura } = response.data;
 
-                const fileURL = URL.createObjectURL(blob);
-                window.open(fileURL, "_blank");
-
-                setTimeout(() => {
-                    URL.revokeObjectURL(fileURL);
-                }, 100);
-
                 onSuccess(
-                    estadoFactura
-                        ? "Copia de factura descargada"
+                    estadoFactura === "consultada"
+                        ? "Factura consultada correctamente"
                         : "Factura generada correctamente"
                 );
+                setTimeout(() => {
+                    const fileURL = URL.createObjectURL(blob);
+                    window.open(fileURL, "_blank");
 
-                toast.success(
-                    estadoFactura
-                        ? "Copia de factura descargada"
-                        : "Factura generada correctamente"
-                );
+                    setTimeout(() => {
+                        URL.revokeObjectURL(fileURL);
+                    }, 100);
+                }, 1500);
             } else {
                 toast.error("No se pudo generar la factura");
             }

--- a/src/services/customerService.ts
+++ b/src/services/customerService.ts
@@ -212,8 +212,7 @@ export async function downloadReceiptService(
             } as OperationType<null>;
         }
 
-        // Leer cabecera
-        const estadoFactura = data.headers.get("X-Estado-Factura");
+        const estadoFactura = data.headers.get("X-Factura-Estado");
         const disposition = data.headers.get("Content-Disposition");
         let filename = `factura-${nit}-${anio}-${month}.pdf`; // Filename
 


### PR DESCRIPTION
This pull request introduces several improvements and minor fixes across the API layer, UI feedback, and code consistency. The main themes are API endpoint updates, header handling, and user feedback improvements.

**API and Endpoint Updates:**
- Changed the endpoint in `downloadReceiptApi` from `/api/factura/generar` to `/api/factura/generar-pdf` to reflect the correct PDF generation route.
- Updated the code to read the correct response header for receipt status, changing from `X-Estado-Factura` to `X-Factura-Estado` in `downloadReceiptService`.

**API Request Handling and Typing:**
- Moved the `RequestInitWithDuplex` type definition to the top-level scope in `route.ts` for reuse and clarity. ([src/app/api/[...path]/route.tsR5-R8](diffhunk://#diff-d78302eb5e12caae87574250bb4979cdfa5aaedaa0170a6414e3a8bd20d5daf3R5-R8), [src/app/api/[...path]/route.tsL19-L22](diffhunk://#diff-d78302eb5e12caae87574250bb4979cdfa5aaedaa0170a6414e3a8bd20d5daf3L19-L22))
- Updated the assignment of the `duplex` property to use `as const` for stricter typing in fetch options. ([src/app/api/[...path]/route.tsL31-R31](diffhunk://#diff-d78302eb5e12caae87574250bb4979cdfa5aaedaa0170a6414e3a8bd20d5daf3L31-R31))
- Cleaned up comments and clarified logic for setting `Content-Type` headers in `apiService`, ensuring correct handling of `FormData` and JSON payloads.
- Removed redundant comments related to 204 No Content responses in `apiService`.

**UI and User Feedback Improvements:**
- Improved the success message logic in `SliderCheckout` to provide clearer feedback based on the `estadoFactura` value and adjusted the timing for opening the generated PDF.
- Cleaned up unused comments and code related to state and refs in `ClientManagementPage` for better maintainability.